### PR TITLE
Fix for spoqify delay

### DIFF
--- a/AnonymizedRadios.js
+++ b/AnonymizedRadios.js
@@ -13,10 +13,10 @@
       let anonymizedURL = e.data.replace("https://open.spotify.com", "");
 
       Spicetify.Platform.History.push(anonymizedURL + "_+");
-			setTimeout(() => {
-				Spicetify.Platform.History.push(anonymizedURL);
-				Spicetify.showNotification("Radio anonymized!", false, 1000);
-			}, 2000);
+  		setTimeout(() => {
+  			Spicetify.Platform.History.repalce(anonymizedURL);
+  			Spicetify.showNotification("Radio anonymized!", false, 1000);
+  		}, 3000);
     });
 
     sse.addEventListener("error", function (e) {

--- a/AnonymizedRadios.js
+++ b/AnonymizedRadios.js
@@ -12,7 +12,11 @@
       sse.close();
       let anonymizedURL = e.data.replace("https://open.spotify.com", "");
 
-      Spicetify.Platform.History.push(anonymizedURL);
+      Spicetify.Platform.History.push(anonymizedURL + "_+");
+			setTimeout(() => {
+				Spicetify.Platform.History.push(anonymizedURL);
+				Spicetify.showNotification("Radio anonymized!", false, 1000);
+			}, 2000);
     });
 
     sse.addEventListener("error", function (e) {


### PR DESCRIPTION
The first load of a spoqify playlist seems to always be empty. A refresh fixes it in the browser but no way to do that in the client with Spicetify. So send the client to a dummy url and then send them to the proper one after a short delay.

Fixes part of https://github.com/BitesizedLion/AnonymizedRadios/issues/3#issue-1986409208